### PR TITLE
feat(client): add late fee policy support for clients

### DIFF
--- a/cmd/go-invoice/main.go
+++ b/cmd/go-invoice/main.go
@@ -91,6 +91,7 @@ Key features:
 	rootCmd.AddCommand(a.buildInvoiceCommand())
 	rootCmd.AddCommand(a.buildImportCommand())
 	rootCmd.AddCommand(a.buildGenerateCommand())
+	rootCmd.AddCommand(a.buildMigrateLateFeeCommand())
 
 	return rootCmd
 }

--- a/cmd/go-invoice/migrate_late_fee.go
+++ b/cmd/go-invoice/migrate_late_fee.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// buildMigrateLateFeeCommand creates a command to enable late fees for all existing clients
+func (a *App) buildMigrateLateFeeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "migrate-late-fee",
+		Short: "Enable late fee policy for all existing clients",
+		Long:  "Updates all existing clients to enable the late fee policy by default",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			// Load configuration
+			configPath, _ := cmd.Flags().GetString("config")
+			config, err := a.configService.LoadConfig(ctx, configPath)
+			if err != nil {
+				return fmt.Errorf("failed to load configuration: %w", err)
+			}
+
+			// Create storage instances
+			_, clientStorage := a.createStorageInstances(config.Storage.DataDir)
+
+			// Get all clients
+			result, err := clientStorage.ListClients(ctx, false, 0, 0)
+			if err != nil {
+				return fmt.Errorf("failed to list clients: %w", err)
+			}
+
+			if len(result.Clients) == 0 {
+				a.logger.Info("No clients found to migrate")
+				return nil
+			}
+
+			// Update each client to enable late fees
+			updated := 0
+			skipped := 0
+			for _, client := range result.Clients {
+				if client.LateFeeEnabled {
+					a.logger.Info("Client already has late fee enabled, skipping", "name", client.Name)
+					skipped++
+					continue
+				}
+
+				client.LateFeeEnabled = true
+				if err := clientStorage.UpdateClient(ctx, client); err != nil {
+					a.logger.Error("failed to update client", "name", client.Name, "error", err)
+					continue
+				}
+
+				a.logger.Info("Enabled late fee policy for client", "name", client.Name)
+				updated++
+			}
+
+			a.logger.Info("Migration complete",
+				"total", len(result.Clients),
+				"updated", updated,
+				"skipped", skipped,
+			)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/models/client.go
+++ b/internal/models/client.go
@@ -240,6 +240,7 @@ type CreateClientRequest struct {
 	ApproverContacts string  `json:"approver_contacts,omitempty"`
 	CryptoFeeEnabled bool    `json:"crypto_fee_enabled"`
 	CryptoFeeAmount  float64 `json:"crypto_fee_amount,omitempty"`
+	LateFeeEnabled   bool    `json:"late_fee_enabled"`
 }
 
 // Validate validates the create client request

--- a/internal/models/client_test.go
+++ b/internal/models/client_test.go
@@ -1082,6 +1082,43 @@ func (suite *ClientTestSuite) TestHasCompleteInfo() {
 	}
 }
 
+func (suite *ClientTestSuite) TestLateFeeEnabled() {
+	t := suite.T()
+
+	tests := []struct {
+		name           string
+		lateFeeEnabled bool
+		expected       bool
+	}{
+		{
+			name:           "LateFeeEnabled",
+			lateFeeEnabled: true,
+			expected:       true,
+		},
+		{
+			name:           "LateFeeDisabled",
+			lateFeeEnabled: false,
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			client := &Client{
+				ID:             "CLIENT-001",
+				Name:           "Test Client",
+				Email:          "test@example.com",
+				Active:         true,
+				LateFeeEnabled: tt.lateFeeEnabled,
+				CreatedAt:      time.Now(),
+				UpdatedAt:      time.Now(),
+			}
+
+			assert.Equal(t, tt.expected, client.LateFeeEnabled)
+		})
+	}
+}
+
 func (suite *ClientTestSuite) TestCreateClientRequestValidate() {
 	t := suite.T()
 
@@ -1107,6 +1144,15 @@ func (suite *ClientTestSuite) TestCreateClientRequestValidate() {
 				Phone:   "+1-555-123-4567",
 				Address: "123 Main St, City, State 12345",
 				TaxID:   "12-3456789",
+			},
+			expectError: false,
+		},
+		{
+			name: "ValidRequestWithLateFee",
+			request: CreateClientRequest{
+				Name:           "Test Client",
+				Email:          "test@example.com",
+				LateFeeEnabled: true,
 			},
 			expectError: false,
 		},

--- a/internal/models/invoice.go
+++ b/internal/models/invoice.go
@@ -51,6 +51,7 @@ type Client struct {
 	Active           bool      `json:"active"`
 	CryptoFeeEnabled bool      `json:"crypto_fee_enabled"`
 	CryptoFeeAmount  float64   `json:"crypto_fee_amount,omitempty"`
+	LateFeeEnabled   bool      `json:"late_fee_enabled"`
 	CreatedAt        time.Time `json:"created_at"`
 	UpdatedAt        time.Time `json:"updated_at"`
 }

--- a/internal/services/client_service.go
+++ b/internal/services/client_service.go
@@ -101,6 +101,9 @@ func (s *ClientService) CreateClient(ctx context.Context, req models.CreateClien
 	client.CryptoFeeEnabled = req.CryptoFeeEnabled
 	client.CryptoFeeAmount = req.CryptoFeeAmount
 
+	// Set late fee settings
+	client.LateFeeEnabled = req.LateFeeEnabled
+
 	if req.ApproverContacts != "" {
 		if err := client.UpdateApproverContacts(ctx, req.ApproverContacts); err != nil {
 			return nil, fmt.Errorf("failed to set client approver contacts: %w", err)

--- a/internal/templates/default.html
+++ b/internal/templates/default.html
@@ -530,6 +530,16 @@
             </section>
             {{end}}
 
+            <!-- Late Fee Notice -->
+            {{if .Client.LateFeeEnabled}}
+            <section class="late-fee-notice" style="margin-top: 30px; padding: 20px; background: #fff3cd; border-left: 4px solid #ffc107; border-radius: 4px;">
+                <h4 style="font-size: 14px; font-weight: 600; color: #856404; margin-bottom: 10px;">Late Payment Policy</h4>
+                <p style="font-size: 12px; color: #856404; line-height: 1.6; margin: 0;">
+                    Invoices not paid within the specified payment terms will accrue interest at a rate of <strong>1.5% per month (18% APR)</strong> from the due date until paid in full. This policy is in place to encourage timely payment per our agreed terms. Thank you for your understanding and cooperation.
+                </p>
+            </section>
+            {{end}}
+
             <!-- Footer -->
             <footer class="invoice-footer">
                 <p>Thank you for your business!</p>


### PR DESCRIPTION
Introduce a new LateFeeEnabled flag to clients to enable late fee policy
on invoices (1.5% per month / 18% APR). Add CLI flags to create and update
clients with late fee option. Display late fee notice in invoice templates
when enabled.

Add migrate-late-fee command to bulk enable late fees for existing clients,
facilitating easier adoption of the new policy across all clients.

Include validation tests for LateFeeEnabled field to ensure correct behavior.