### PR TITLE
[Sync] Update project files from source repository (31ecff7)

### DIFF
--- a/.github/CODE_STANDARDS.md
+++ b/.github/CODE_STANDARDS.md
@@ -45,7 +45,6 @@ When in doubt, check the official docs:
 * 📃 [godoc](https://pkg.go.dev/golang.org/x/tools/cmd/godoc)
 * 🔧 [gofmt](https://golang.org/cmd/gofmt/)
 * 📊 [golangci-lint](https://golangci-lint.run/)
-* 📈 [Go Report Card](https://goreportcard.com/)
 
 <br/>
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,6 @@ We follow [Effective Go](https://golang.org/doc/effective_go.html), plus:
 
 * 📖 [godoc](https://godoc.org/golang.org/x/tools/cmd/godoc)
 * 🧼 [golangci-lint](https://golangci-lint.run/)
-* 🧾 [Go Report Card](https://goreportcard.com/)
 
 Format your code with `gofmt`, lint with `golangci-lint`, and keep your diffs minimal.
 

--- a/.github/env/10-mage-x.env
+++ b/.github/env/10-mage-x.env
@@ -36,7 +36,7 @@
 # ================================================================================================
 
 # MAGE-X version
-MAGE_X_VERSION=v1.24.1
+MAGE_X_VERSION=v1.25.0
 
 # For mage-x development, set to 'true' to use local version instead of downloading from releases
 MAGE_X_USE_LOCAL=false
@@ -70,9 +70,9 @@ MAGE_X_FORMAT_EXCLUDE_PATHS=vendor,node_modules,.git,.idea
 # ================================================================================================
 
 MAGE_X_GITLEAKS_VERSION=8.30.1
-MAGE_X_GOFUMPT_VERSION=v0.10.0
+MAGE_X_GOFUMPT_VERSION=v0.11.0
 MAGE_X_GOLANGCI_LINT_VERSION=v2.12.2
-MAGE_X_GORELEASER_VERSION=v2.17.0
+MAGE_X_GORELEASER_VERSION=v2.17.1
 MAGE_X_GOVULNCHECK_VERSION=v1.1.4
 MAGE_X_GO_SECONDARY_VERSION=1.24.x
 MAGE_X_GO_VERSION=1.24.x

--- a/.github/env/10-pre-commit.env
+++ b/.github/env/10-pre-commit.env
@@ -53,7 +53,7 @@ GO_PRE_COMMIT_ALL_FILES=true
 # ================================================================================================
 
 GO_PRE_COMMIT_GOLANGCI_LINT_VERSION=v2.12.2
-GO_PRE_COMMIT_FUMPT_VERSION=v0.10.0
+GO_PRE_COMMIT_FUMPT_VERSION=v0.11.0
 GO_PRE_COMMIT_GOIMPORTS_VERSION=latest
 GO_PRE_COMMIT_GITLEAKS_VERSION=v8.30.1
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,7 +43,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## What Changed

* Removed "Go Report Card" references from documentation in `.github/CODE_STANDARDS.md` and `.github/CONTRIBUTING.md`
* Updated `MAGE_X_VERSION` from `v1.24.1` to `v1.25.0` in `.github/env/10-mage-x.env`
* Updated `MAGE_X_GOFUMPT_VERSION` from `v0.10.0` to `v0.11.0` in `.github/env/10-mage-x.env`
* Updated `MAGE_X_GORELEASER_VERSION` from `v2.17.0` to `v2.17.1` in `.github/env/10-mage-x.env`
* Updated `GO_PRE_COMMIT_FUMPT_VERSION` from `v0.10.0` to `v0.11.0` in `.github/env/10-pre-commit.env`
* Updated `ossf/scorecard-action` from `4eaacf0543bb3f2c246792bd56e8cdeffafb205a` (v2.4.3) to `2d1146689b8cda280b9bc96326124645441f03bc` (v2.4.4) in `.github/workflows/scorecard.yml`

## Why It Was Necessary

* Removes outdated or no longer needed Go Report Card tooling references from contributor documentation
* Updates build and development tooling to latest stable versions for improved functionality and bug fixes
* Ensures security scanning workflow uses the most recent scorecard action version with latest security checks

## Testing Performed

* Version bumps for mage-x, gofumpt, and goreleaser follow semantic versioning and have been validated by their respective maintainers
* Documentation changes verified to ensure no broken references or formatting issues
* CI workflow changes will be validated automatically when the workflow runs with the updated scorecard action version

## Impact / Risk

* **Low Risk**: Version updates are minor/patch releases with backwards compatibility
* **Documentation**: Removal of Go Report Card references simplifies tooling documentation without affecting functionality
* **CI/CD**: Scorecard action update maintains same interface while providing updated security checks

<!-- go-broadcast-metadata
group:
  id: mrz-projects-public
  name: mrz-projects-public
diff_info:
  staged_repo_available: true
  changed_files_count: 5
  files_with_original_content: 5
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 31ecff74272ac87c2e6ed4bfe911cea832a98edb
  target_repo: mrz1836/go-invoice
  sync_commit: 55d115463866cc24d307c2dda766c6be688e089a
  sync_time: 2026-07-28T10:50:58-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 338
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 759
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 289
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 2
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 405
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 274
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 918
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 1803
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 496
performance:
  total_files: 104
-->
